### PR TITLE
Add python to available packages list

### DIFF
--- a/config
+++ b/config
@@ -1015,3 +1015,27 @@ CONFIG_PACKAGE_iptraf-ng=y
 CONFIG_PACKAGE_nano=m
 # CONFIG_SSP_SUPPORT is not set
 # CONFIG_VERSION_FILENAMES is not set
+
+#
+# Python
+#
+CONFIG_PACKAGE_python=m
+CONFIG_PACKAGE_python-base=m
+CONFIG_PACKAGE_python-codecs=m
+CONFIG_PACKAGE_python-compiler=m
+CONFIG_PACKAGE_python-ctypes=m
+CONFIG_PACKAGE_python-db=m
+CONFIG_PACKAGE_python-decimal=m
+CONFIG_PACKAGE_python-distutils=m
+CONFIG_PACKAGE_python-email=m
+CONFIG_PACKAGE_python-light=m
+CONFIG_PACKAGE_python-logging=m
+CONFIG_PACKAGE_python-multiprocessing=m
+CONFIG_PACKAGE_python-ncurses=m
+CONFIG_PACKAGE_python-openssl=m
+CONFIG_PACKAGE_python-pip=m
+CONFIG_PACKAGE_python-pydoc=m
+CONFIG_PACKAGE_python-setuptools=m
+CONFIG_PACKAGE_python-sqlite3=m
+CONFIG_PACKAGE_python-unittest=m
+CONFIG_PACKAGE_python-xml=m


### PR DESCRIPTION
To be compiled with OTB dependencies

Depends on: https://github.com/ovh/overthebox-openwrt/pull/19.
Without this, python-gdbm won't compile, so `python` will not be available.

--> submodule references not updated, I can't guess what will the commit id be
