### PR TITLE
Do not pre-install dnsmasq in the image anymore

### DIFF
--- a/config
+++ b/config
@@ -393,6 +393,7 @@ CONFIG_PACKAGE_debugfs=y
 CONFIG_PACKAGE_dkjson=m
 CONFIG_PACKAGE_dmesg=y
 CONFIG_PACKAGE_dmidecode=y
+# CONFIG_PACKAGE_dnsmasq is not set
 CONFIG_PACKAGE_dnsmasq-full=y
 CONFIG_PACKAGE_dnsmasq_full_auth=y
 CONFIG_PACKAGE_dnsmasq_full_dhcpv6=y


### PR DESCRIPTION
We only need dnsmasq-full, and since dnsmasq-full is a VARIANT of
dnsmasq, they share most of their files. Installing both is dangerous,
because depending on the order of installation we may get unpredictable
results.

Signed-off-by: Martin Wetterwald <martin.wetterwald@corp.ovh.com>