### PR TITLE
Add a local mirror in the config

### DIFF
--- a/config
+++ b/config
@@ -1000,3 +1000,4 @@ CONFIG_shadow-all=y
 # CONFIG_BUSYBOX_CONFIG_TRACEROUTE6 is not set
 # CONFIG_SSP_SUPPORT is not set
 # CONFIG_VERSION_FILENAMES is not set
+CONFIG_LOCALMIRROR="http://downloads.overthebox.ovh/build_cache"


### PR DESCRIPTION
http://downloads.overthebox.ovh/build_cache contains all the needed
files to do a full build

This will avoid many problems on builds when files are no longer
accessible

Signed-off-by: Lucas BEE <lucas.bee@corp.ovh.com>